### PR TITLE
Move Shadow Props to different View

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -108,15 +108,11 @@ export default class ActionButtonItem extends Component {
         style={[animatedViewStyle, parentStyle]}
       >
         <View
-          style={[
-            {
-              width: this.props.size,
-              height: this.props.size,
-              borderRadius: size / 2
-            },
-            !hideShadow && shadowStyle,
-            !hideShadow && this.props.shadowStyle
-          ]}
+          style={{
+            width: this.props.size,
+            height: this.props.size,
+            borderRadius: size / 2
+          }}
         >
           <Touchable
             background={touchableBackground(
@@ -126,7 +122,10 @@ export default class ActionButtonItem extends Component {
             activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
             onPress={this.props.onPress}
           >
-            <View style={[buttonStyle]}>
+            <View style={[
+              buttonStyle,
+              !hideShadow ? {...shadowStyle, ...this.props.shadowStyle} : null
+            ]}>
               {this.props.children}
             </View>
           </Touchable>


### PR DESCRIPTION
Currently the shadow is rendered on an item without a background color, which causes a warning.

This commit moves the shadow props to the same View that contains the backgroundColor, thus removing the warning.

Makes no difference to usage/appearance.